### PR TITLE
Lock kvm-bindings version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ version = "0.0.*"
 version = "0.6.1"
 
 [target.'cfg(target_os = "linux")'.dependencies.kvm-bindings]
-version = "0.*"
+version = "0.3.1"
 
 [target.'cfg(target_os = "linux")'.dependencies.vmm-sys-util]
 version = "0.7.0"


### PR DESCRIPTION
Lock upstream dependency which was recently updated causing breaking changes.